### PR TITLE
Add variable PORT to allow for non-standard TCP port by SSH

### DIFF
--- a/capture.sh
+++ b/capture.sh
@@ -23,6 +23,7 @@ if [ $# == 0 ]; then
 fi
 
 HOST=172.16.1.1
+PORT=22222
 USER=virl
 FIFO=/tmp/remotecapture.fifo
 
@@ -34,7 +35,7 @@ fi
 
 # make sure the param is indeed a tap interface
 if [[ "$1" =~ ^tap[0-9a-f]{8}-[0-9a-f]{2}$ ]]; then
-  /usr/bin/ssh -n >$FIFO $USER@$HOST sudo stdbuf -o0 tcpdump -w- -s0 -vni $1 
+  /usr/bin/ssh -n >$FIFO -p $PORT $USER@$HOST sudo stdbuf -o0 tcpdump -w- -s0 -vni $1 
 else
   echo "$1 does not look like a tap interface"
 fi


### PR DESCRIPTION
Added variable PORT to capture.sh so that it's easy to change from the default TCP port 22.  I find this particularly useful when I am running VIRL on my laptop while VPN'd into my company's network.  With local network access blocked, I have to use SSH forwarding and NAT to reach the VIRL VM.  This is discussed in detail at:

https://cisco.jiveon.com/people/rschmied/blog/2015/07/08/virl-in-a-vm-and-dreaded-anyconnect

I modified capture.sh so that I can still reach my VIRL VM and use this script to forward the capture over a non-standard TCP port for SSH.