### PR TITLE
Add capture port

### DIFF
--- a/capture.sh
+++ b/capture.sh
@@ -23,6 +23,7 @@ if [ $# == 0 ]; then
 fi
 
 HOST=172.16.1.1
+PORT=22222
 USER=virl
 FIFO=/tmp/remotecapture.fifo
 
@@ -34,7 +35,7 @@ fi
 
 # make sure the param is indeed a tap interface
 if [[ "$1" =~ ^tap[0-9a-f]{8}-[0-9a-f]{2}$ ]]; then
-  /usr/bin/ssh -n >$FIFO $USER@$HOST sudo stdbuf -o0 tcpdump -w- -s0 -vni $1 
+  /usr/bin/ssh -n >$FIFO -p $PORT $USER@$HOST sudo stdbuf -o0 tcpdump -w- -s0 -vni $1 
 else
   echo "$1 does not look like a tap interface"
 fi

--- a/capture.sh
+++ b/capture.sh
@@ -23,7 +23,7 @@ if [ $# == 0 ]; then
 fi
 
 HOST=172.16.1.1
-PORT=22222
+PORT=22
 USER=virl
 FIFO=/tmp/remotecapture.fifo
 


### PR DESCRIPTION
Add a new variable PORT to the capture.sh script so that a user can choose a non-standard port for SSH connectivity.

This can be useful when running VIRL on a machine that is also using VPN into a corporate environment where local interface switching is not allowed.

This is based in large part on the information presented here:

https://cisco.jiveon.com/people/rschmied/blog/2015/07/08/virl-in-a-vm-and-dreaded-anyconnect

